### PR TITLE
refactor: rename OpenGeminiClient to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opengemini-client-rust
 
-![license](https://img.shields.io/badge/license-Apache2.0-green) ![language](https://img.shields.io/badge/language-Rust-blue.svg) [![release](https://img.shields.io/github/v/tag/opengemini/opengemini-client-rust?label=release&color=blue)](https://github.com/opengemini/opengemini-client-rust/releases)
+![license](https://img.shields.io/badge/license-Apache2.0-green) ![language](https://img.shields.io/badge/language-Rust-blue.svg) [![release](https://img.shields.io/github/v/tag/opengemini/opengemini-client-rust?label=crates.io&color=blue)](https://crates.io/crates/opengemini)
 
 English | [简体中文](README_CN.md)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod opengemini_client;
 
-pub use opengemini_client::OpenGeminiClient;
+pub use opengemini_client::Client;

--- a/src/opengemini_client.rs
+++ b/src/opengemini_client.rs
@@ -1,8 +1,8 @@
-pub struct OpenGeminiClient {
+pub struct Client {
 }
 
-impl OpenGeminiClient {
+impl Client {
     pub fn new() -> Self {
-        OpenGeminiClient {}
+        Client {}
     }
 }


### PR DESCRIPTION
1. rename `OpengeminiClient` to `Client`
2. as a consensus, most rust library use crates not github release, so replace `release` shields to `crates.io`