### PR TITLE
build: use thiserror create a simple error enum and supplement config fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ homepage = "https://github.com/openGemini/opengemini-client-rust"
 reqwest = { version = "0.12.7", features = ["json", "__rustls"] }
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.125"
+thiserror = "1.0.64"

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,6 @@ pub struct AuthConfig {
     token: String,
 }
 
-pub struct TlsConfig {}
 
 pub struct Config {
     Address: Vec<Address>,
@@ -41,7 +40,5 @@ pub struct Config {
     timeout: Duration,
     connectionTimeout: Duration,
     gzip_enabled: bool,
-    tls_enabled: bool,
     auth_config: AuthConfig,
-    tls_config: TlsConfig,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,12 +33,11 @@ pub struct AuthConfig {
     token: String,
 }
 
-
 pub struct Config {
     Address: Vec<Address>,
     batch_config: BatchConfig,
     timeout: Duration,
-    connectionTimeout: Duration,
+    connect_timeout: Duration,
     gzip_enabled: bool,
     auth_config: AuthConfig,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,37 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use thiserror::Error;
 
-use std::time::Duration;
-
-pub struct Address {
-    host: String,
-    port: u8,
-}
-
-pub struct BatchConfig {
-    batchInterval: Duration,
-    batchSize: u8,
-}
-
-type AuthType = u8;
-
-pub struct AuthConfig {
-    authType: AuthType,
-    username: String,
-    password: String,
-    token: String,
-}
-
-pub struct TlsConfig {}
-
-pub struct Config {
-    Address: Vec<Address>,
-    batch_config: BatchConfig,
-    timeout: Duration,
-    connectionTimeout: Duration,
-    gzip_enabled: bool,
-    tls_enabled: bool,
-    auth_config: AuthConfig,
-    tls_config: TlsConfig,
+// Client Error
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("Connection error")]
+    ConnectionError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod config;
+mod error;
 mod opengemini_client;
 mod url_const;
 


### PR DESCRIPTION
1. use thiserror create a simple error enum,  will add other error types in future commits.
2. supplement config fields
